### PR TITLE
Specify diffusers revision to fix LCMScheduler AttributeError

### DIFF
--- a/main.py
+++ b/main.py
@@ -12,7 +12,8 @@ class Predictor:
         model = DiffusionPipeline.from_pretrained(
             "SimianLuo/LCM_Dreamshaper_v7",
             custom_pipeline="latent_consistency_txt2img",
-            custom_revision="main"
+            custom_revision="main",
+            revision="fb9c5d"
         )
         model.to(torch_device="cpu", torch_dtype=torch.float32).to('mps:0')
         return model


### PR DESCRIPTION
This usage is listed as deprecated, but fetching from "main" stopped working with the current version of the code here.

https://huggingface.co/SimianLuo/LCM_Dreamshaper_v7/blob/main/README.md#usage-deprecated

Relates to: https://github.com/replicate/latent-consistency-model/issues/8 (but this may not be the optimal fix)