### PR TITLE
Fix AttributeError for LCMScheduler

### DIFF
--- a/main.py
+++ b/main.py
@@ -12,7 +12,8 @@ class Predictor:
         model = DiffusionPipeline.from_pretrained(
             "SimianLuo/LCM_Dreamshaper_v7",
             custom_pipeline="latent_consistency_txt2img",
-            custom_revision="main"
+            custom_revision="main",
+            revision="fb9c5d"
         )
         model.to(torch_device="cpu", torch_dtype=torch.float32).to('mps:0')
         return model


### PR DESCRIPTION
Hi! 

Just tried to run this on my M1 Max and it crashed with this error:
```AttributeError: module diffusers has no attribute LCMScheduler. Did you mean: 'DDIMScheduler'```

A bit of search and managed to fix it locally and thought to PR the change for others too 👨‍💻

Feel free to close it if it is not relevant anymore ☺️.
